### PR TITLE
fix turbo, maybe

### DIFF
--- a/source/Remapper.cpp
+++ b/source/Remapper.cpp
@@ -194,18 +194,16 @@ uint32_t Remapper::Remap(uint32_t hidstate, uint32_t newpressedkeys)
         if((hidstate & m_remapturboobjects[i].onkey) == m_remapturboobjects[i].onkey)
         {
             newstate &= ~m_remapturboobjects[i].onkey;
-            m_remapturboobjects[i].state = !m_remapturboobjects[i].state;
-            m_remapturboobjects[i].frames = 0;
+            if (m_remapturboobjects[i].frames >= m_remapturboobjects[i].framedelay) {
+                m_remapturboobjects[i].frames = 0;
+            } else if (m_remapturboobjects[i].frames * 2 >= m_remapturboobjects[i].framedelay) {
+                newstate ^= m_remapturboobjects[i].newkey;
+            }
+
+            m_remapturboobjects[i].frames++;
             //int len = sprintf_(buf, "Key Pressed, i: %d\n", i);
             //svcOutputDebugString(buf, len);
         }
-
-        if(m_remapturboobjects[i].state && (m_remapturboobjects[i].frames >= m_remapturboobjects[i].framedelay))
-        {
-            newstate = newstate ^ m_remapturboobjects[i].newkey;
-            m_remapturboobjects[i].frames = 0;
-        } else if(m_remapturboobjects[i].state)
-            m_remapturboobjects[i].frames++;
     }
 
     if(m_homebuttonkeys != 0)

--- a/source/hid.cpp
+++ b/source/hid.cpp
@@ -1,201 +1,160 @@
-#include <malloc.h>
-#include <new>
 #include "hid.hpp"
 #include "PadRing.hpp"
-#include <cstring>
-#include "irrst.hpp"
 #include "code_ips.h"
-extern "C"
-{
-    #include "csvc.h"
-    #include "gpio.h"
-    #include "i2c.h"
+#include "irrst.hpp"
+#include <cstring>
+#include <malloc.h>
+#include <new>
+extern "C" {
+#include "csvc.h"
+#include "gpio.h"
+#include "i2c.h"
 }
-static uint8_t ALIGN(8) hidthreadstack[0x1000];
-void Hid::CreateAndMapMemoryBlock()
-{
-    // 0x1000 is rounded off size for 0x2B0
-    Result ret = svcCreateMemoryBlock(&m_sharedmemhandle, 0, 0x1000, (MemPerm)(MEMPERM_READ | MEMPERM_WRITE), MEMPERM_READ);
-    if(R_SUCCEEDED(ret))
-    {
-        mappableInit(0x10000000, 0x14000000);
-        m_addr = mappableAlloc(0x1000);
-        if(m_addr)
-        {
-            ret = svcMapMemoryBlock(m_sharedmemhandle, (u32)m_addr, (MemPerm)(MEMPERM_READ | MEMPERM_WRITE), MEMPERM_DONTCARE);
-            if(ret != 0)
-                *(u32*)ret = (u32)m_addr;
-        }
-        else svcBreak(USERBREAK_ASSERT);
+static uint8_t CTR_ALIGN(8) hidthreadstack[0x1000];
+void Hid::CreateAndMapMemoryBlock() {
+  // 0x1000 is rounded off size for 0x2B0
+  Result ret = svcCreateMemoryBlock(&m_sharedmemhandle, 0, 0x1000,
+                                    (MemPerm)(MEMPERM_READ | MEMPERM_WRITE),
+                                    MEMPERM_READ);
+  if (R_SUCCEEDED(ret)) {
+    mappableInit(0x10000000, 0x14000000);
+    m_addr = mappableAlloc(0x1000);
+    if (m_addr) {
+      ret = svcMapMemoryBlock(m_sharedmemhandle, (u32)m_addr,
+                              (MemPerm)(MEMPERM_READ | MEMPERM_WRITE),
+                              MEMPERM_DONTCARE);
+      if (ret != 0)
+        *(u32 *)ret = (u32)m_addr;
+    } else
+      svcBreak(USERBREAK_ASSERT);
 
-    }
-    else svcBreak(USERBREAK_ASSERT);
-    svcCreateEvent(&dummyhandles[2], RESET_STICKY);
-    svcCreateEvent(&dummyhandles[3], RESET_ONESHOT);
-    LightLock_Init(&m_sleeplock);
-}
-
-void Hid::CreateRingsOnSharedmemoryBlock()
-{
-    m_padring = new(m_addr)PadRing;
-    m_touchring = new((void*)((u32)(m_addr) + 0xA8))TouchRing;
-    m_accelring = new((void*)((u32)(m_addr) + 0x108))AccelerometerRing;
-    m_gyroring = new((void*)((u32)(m_addr) + 0x158))GyroscopeRing;
-    m_debugpadring = new((void*)((u32)(m_addr) + 0x238))DebugPadRing;
+  } else
+    svcBreak(USERBREAK_ASSERT);
+  svcCreateEvent(&dummyhandles[2], RESET_STICKY);
+  svcCreateEvent(&dummyhandles[3], RESET_ONESHOT);
+  LightLock_Init(&m_sleeplock);
 }
 
-void Hid::InitializePad()
-{
-    if(R_FAILED(codecInit())) svcBreak(USERBREAK_ASSERT);
-
-    m_pad.Initialize();
-    m_pad.SetPadRing(m_padring);
-
-    m_touch.Initialize();
-    m_touch.SetTouchRing(m_touchring);
+void Hid::CreateRingsOnSharedmemoryBlock() {
+  m_padring = new (m_addr) PadRing;
+  m_touchring = new ((void *)((u32)(m_addr) + 0xA8)) TouchRing;
+  m_accelring = new ((void *)((u32)(m_addr) + 0x108)) AccelerometerRing;
+  m_gyroring = new ((void *)((u32)(m_addr) + 0x158)) GyroscopeRing;
+  m_debugpadring = new ((void *)((u32)(m_addr) + 0x238)) DebugPadRing;
 }
 
-void Hid::InitializeAccelerometer()
-{
-    m_accel.Initialize();
-    m_accel.SetAccelerometerRing(m_accelring);
+void Hid::InitializePad() {
+  if (R_FAILED(codecInit()))
+    svcBreak(USERBREAK_ASSERT);
+
+  m_pad.Initialize();
+  m_pad.SetPadRing(m_padring);
+
+  m_touch.Initialize();
+  m_touch.SetTouchRing(m_touchring);
 }
 
-void Hid::InitializeGyroscope()
-{
-    if(R_FAILED(i2cHidInit())) svcBreak(USERBREAK_ASSERT);
-    if(R_FAILED(gpiohidInit())) svcBreak(USERBREAK_ASSERT);
-
-    m_gyro.Initialize();
-    m_gyro.SetGyroscopeRing(m_gyroring);
+void Hid::InitializeAccelerometer() {
+  m_accel.Initialize();
+  m_accel.SetAccelerometerRing(m_accelring);
 }
 
-void Hid::InitializeDebugPad()
-{
-    // We should init i2c here, but that will done by InitlaizeGyroscope
+void Hid::InitializeGyroscope() {
+  if (R_FAILED(i2cHidInit()))
+    svcBreak(USERBREAK_ASSERT);
+  if (R_FAILED(gpiohidInit()))
+    svcBreak(USERBREAK_ASSERT);
 
-    m_debugpad.Initialize();
-    m_debugpad.SetDebugPadRing(m_debugpadring);
+  m_gyro.Initialize();
+  m_gyro.SetGyroscopeRing(m_gyroring);
 }
 
-static inline bool isServiceUsable(const char *name)
-{
-    bool r;
-    return R_SUCCEEDED(srvIsServiceRegistered(&r, name)) && r;
+void Hid::InitializeDebugPad() {
+  // We should init i2c here, but that will done by InitlaizeGyroscope
+
+  m_debugpad.Initialize();
+  m_debugpad.SetDebugPadRing(m_debugpadring);
+}
+
+static inline bool isServiceUsable(const char *name) {
+  bool r;
+  return R_SUCCEEDED(srvIsServiceRegistered(&r, name)) && r;
 }
 
 u8 irneeded = 0;
-static void irInit()
-{
-    while(!isServiceUsable("ir:u")) svcSleepThread(1e+9); // Wait For service
-    srvSetBlockingPolicy(true);
-    Result ret = iruInit_();
-    if(ret == 0)
-        irneeded = 1;
-    srvSetBlockingPolicy(false);
+static void irInit() {
+  while (!isServiceUsable("ir:u"))
+    svcSleepThread(1e+9); // Wait For service
+  srvSetBlockingPolicy(true);
+  Result ret = iruInit_();
+  if (ret == 0)
+    irneeded = 1;
+  srvSetBlockingPolicy(false);
 }
 
 extern Handle irtimer;
-static void SamplingFunction(void *argv)
-{
-    Hid *hid = (Hid*)argv;
-    Result ret = 0;
-    u32 touchscreendata, circlepaddata;
-    Handle *padtimer = hid->GetPad()->GetTimer();
-    Handle *accelintrevent = hid->GetAccelerometer()->GetIntrEvent();
-    Handle *gyrointrevent = hid->GetGyroscope()->GetIntrEvent();
-    Handle *debugpadtimer = hid->GetDebugPad()->GetTimer();
-    LightLock *lock = hid->GetSleepLock();
-    irInit();
-    int32_t out;
-    while(!*hid->ExitThread())
-    {
-        Handle handles[] = {irtimer, *padtimer, *debugpadtimer, *gyrointrevent, *accelintrevent};
-        LightLock_Lock(lock);
-        ret = svcWaitSynchronizationN(&out, handles, 5, false, -1LL);
-        if(!hid->GetGyroscope()->m_issetupdone && osGetTime() - hid->GetGyroscope()->timeenable > 90 && hid->GetGyroscope()->GetRefCount() > 0)
-        {
-            hid->GetGyroscope()->SetupForSampling();
-            hid->GetGyroscope()->m_issetupdone = true;
-        }
-        switch(out){
-
-            case 0:
-            {
-                irSampling();
-                break;
-            }
-
-            case 1:
-            {
-                ret = CDCHID_GetData(&touchscreendata, &circlepaddata);
-                if(ret == 0)
-                {
-                    hid->GetPad()->Sampling(circlepaddata, hid->GetRemapperObject());
-                    hid->GetTouch()->Sampling(touchscreendata, hid->GetRemapperObject());
-                }
-                break;
-            }
-
-            case 2:
-            {
-                hid->GetDebugPad()->Sampling();
-                break;
-            }
-
-            case 3:
-            {
-                hid->GetGyroscope()->Sampling();
-                break;
-            }
-
-            case 4:
-            {
-                hid->GetAccelerometer()->Sampling();
-                break;
-            }
-        }
-        if(ret > 0) svcBreak(USERBREAK_ASSERT);
-
-        LightLock_Unlock(lock);
+static void SamplingFunction(void *argv) {
+  Hid *hid = (Hid *)argv;
+  Result ret = 0;
+  u32 touchscreendata, circlepaddata;
+  Handle *padtimer = hid->GetPad()->GetTimer();
+  Handle *accelintrevent = hid->GetAccelerometer()->GetIntrEvent();
+  Handle *gyrointrevent = hid->GetGyroscope()->GetIntrEvent();
+  Handle *debugpadtimer = hid->GetDebugPad()->GetTimer();
+  LightLock *lock = hid->GetSleepLock();
+  irInit();
+  int32_t out;
+  while (!*hid->ExitThread()) {
+    Handle handles[] = {irtimer, *padtimer, *debugpadtimer, *gyrointrevent,
+                        *accelintrevent};
+    LightLock_Lock(lock);
+    ret = svcWaitSynchronizationN(&out, handles, 5, false, -1LL);
+    if (!hid->GetGyroscope()->m_issetupdone &&
+        osGetTime() - hid->GetGyroscope()->timeenable > 90 &&
+        hid->GetGyroscope()->GetRefCount() > 0) {
+      hid->GetGyroscope()->SetupForSampling();
+      hid->GetGyroscope()->m_issetupdone = true;
     }
-}
+    switch (out) {
 
-void Hid::StartThreadsForSampling()
-{
-    if(!m_samplingthreadstarted)
-    {
-        m_padring->Reset();
-        m_touchring->Reset();
-        m_accelring->Reset();
-        m_gyroring->Reset();
-        m_debugpadring->Reset();
-        m_pad.SetTimer();
-        m_debugpad.SetTimer();
-        m_accel.EnableOrDisableInterrupt();
-        m_gyro.EnableSampling();
-        m_gyro.timeenable = osGetTime();
-        m_gyro.m_issetupdone = false;
-        MyThread_Create(&m_samplingthread, SamplingFunction, this, hidthreadstack, 0x1000, 0x15, -2);
-        m_accel.EnableOrDisableInterrupt(0); // disable accelerometer interrupt
-        m_accel.SetAccelerometerStatus(1); // enable accelerometer
-        m_samplingthreadstarted = true;
+    case 0: {
+      irSampling();
+      break;
     }
+
+    case 1: {
+      ret = CDCHID_GetData(&touchscreendata, &circlepaddata);
+      if (ret == 0) {
+        hid->GetPad()->Sampling(circlepaddata, hid->GetRemapperObject());
+        hid->GetTouch()->Sampling(touchscreendata, hid->GetRemapperObject());
+      }
+      break;
+    }
+
+    case 2: {
+      hid->GetDebugPad()->Sampling();
+      break;
+    }
+
+    case 3: {
+      hid->GetGyroscope()->Sampling();
+      break;
+    }
+
+    case 4: {
+      hid->GetAccelerometer()->Sampling();
+      break;
+    }
+    }
+    if (ret > 0)
+      svcBreak(USERBREAK_ASSERT);
+
+    LightLock_Unlock(lock);
+  }
 }
 
-void Hid::EnteringSleepMode()
-{
-    LightLock_Lock(&m_sleeplock); // now that main thread accquired the lock, sampling thread will get stuck
-    svcClearEvent(dummyhandles[2]);
-    iruExit_();
-    
-    PTMSYSM_NotifySleepPreparationComplete(0);
-}
-
-
-void Hid::ExitingSleepMode()
-{
-    LightLock_Unlock(&m_sleeplock); // Unlock lock and then reset timer
+void Hid::StartThreadsForSampling() {
+  if (!m_samplingthreadstarted) {
     m_padring->Reset();
     m_touchring->Reset();
     m_accelring->Reset();
@@ -203,34 +162,72 @@ void Hid::ExitingSleepMode()
     m_debugpadring->Reset();
     m_pad.SetTimer();
     m_debugpad.SetTimer();
-    irInit();
-    
-    PTMSYSM_NotifySleepPreparationComplete(0);
+    m_accel.EnableOrDisableInterrupt();
+    m_gyro.EnableSampling();
+    m_gyro.timeenable = osGetTime();
+    m_gyro.m_issetupdone = false;
+    MyThread_Create(&m_samplingthread, SamplingFunction, this, hidthreadstack,
+                    0x1000, 0x15, -2);
+    m_accel.EnableOrDisableInterrupt(0); // disable accelerometer interrupt
+    m_accel.SetAccelerometerStatus(1);   // enable accelerometer
+    m_samplingthreadstarted = true;
+  }
 }
 
-void Hid::RemapGenFileLoc()
-{
-    m_remapper.GenerateFileLocation();
-    Result ret = m_remapper.ReadConfigFile();
-        if(ret == -1) return;
-        else if(ret) *(u32*)ret = 0xF00FBABE;
-    m_remapper.ParseConfigFile();
+void Hid::EnteringSleepMode() {
+  LightLock_Lock(&m_sleeplock); // now that main thread accquired the lock,
+                                // sampling thread will get stuck
+  svcClearEvent(dummyhandles[2]);
+  iruExit_();
+
+  PTMSYSM_NotifySleepPreparationComplete(0);
 }
 
-void Hid::CheckIfIRPatchExists()
-{
-    Handle fshandle;
-    Result ret = FSUSER_OpenFileDirectly(&fshandle, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, NULL), fsMakePath(PATH_ASCII, "/luma/sysmodules/0004013000003302.ips"), FS_OPEN_READ, 0);
-    if(ret) // Does not exist
-    {
-        u64 archivesd;
-        FSUSER_OpenArchive(&archivesd, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, ""));
-        ret = FSUSER_OpenFileDirectly(&fshandle, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, NULL), fsMakePath(PATH_ASCII, "/luma/sysmodules/0004013000003302.ips"), FS_OPEN_WRITE | FS_OPEN_CREATE, 0);
-        if(R_FAILED(ret)) *(u32*)0xF009F009 = ret; // Shouldn't have happened
-        ret = FSFILE_Write(fshandle, nullptr, 0, code_ips, code_ips_size, 0);
-        if(R_FAILED(ret)) *(u32*)0xf009f010 = ret; // Neither this should happen
-        FSFILE_Close(fshandle);
-        PTMSYSM_RebootAsync(2e+9);
-    }
-   return ;
+void Hid::ExitingSleepMode() {
+  LightLock_Unlock(&m_sleeplock); // Unlock lock and then reset timer
+  m_padring->Reset();
+  m_touchring->Reset();
+  m_accelring->Reset();
+  m_gyroring->Reset();
+  m_debugpadring->Reset();
+  m_pad.SetTimer();
+  m_debugpad.SetTimer();
+  irInit();
+
+  PTMSYSM_NotifySleepPreparationComplete(0);
+}
+
+void Hid::RemapGenFileLoc() {
+  m_remapper.GenerateFileLocation();
+  Result ret = m_remapper.ReadConfigFile();
+  if (ret == -1)
+    return;
+  else if (ret)
+    *(u32 *)ret = 0xF00FBABE;
+  m_remapper.ParseConfigFile();
+}
+
+void Hid::CheckIfIRPatchExists() {
+  Handle fshandle;
+  Result ret = FSUSER_OpenFileDirectly(
+      &fshandle, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, NULL),
+      fsMakePath(PATH_ASCII, "/luma/sysmodules/0004013000003302.ips"),
+      FS_OPEN_READ, 0);
+  if (ret) // Does not exist
+  {
+    u64 archivesd;
+    FSUSER_OpenArchive(&archivesd, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, ""));
+    ret = FSUSER_OpenFileDirectly(
+        &fshandle, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, NULL),
+        fsMakePath(PATH_ASCII, "/luma/sysmodules/0004013000003302.ips"),
+        FS_OPEN_WRITE | FS_OPEN_CREATE, 0);
+    if (R_FAILED(ret))
+      *(u32 *)0xF009F009 = ret; // Shouldn't have happened
+    ret = FSFILE_Write(fshandle, nullptr, 0, code_ips, code_ips_size, 0);
+    if (R_FAILED(ret))
+      *(u32 *)0xf009f010 = ret; // Neither this should happen
+    FSFILE_Close(fshandle);
+    PTMSYSM_RebootAsync(2e+9);
+  }
+  return;
 }


### PR DESCRIPTION
Consider this a bug report, as well as a proposed fix.

The current turbo implementation is buggy, or at least confusing. Holding down a turbo combo causes the state field on the turbo object to cycle with each poll, which causes the rapidly firing button to become locked on seemingly at random each time you press the combo. The turbo button is also only marked as pressed for a single poll, which causes problems with some games.

This PR addresses both issues. Pressing and holding the combo in the press field of a turbo object will cause the combo in the get field to fire rapidly as before, and releasing it will always stop the firing. The duty cycle of the button presses has also been increased to 50%, which solves the presses not being registered in some games. If the locking behavior of the original implementation was intentional, I'd at least like this behavior to be toggleable, just because I prefer it like this. 