### PR TITLE
Add build files (+vscode) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 *.cxi
+*.elf
+*.3dsx
+*.smdh
+
+build/
+sdmc/
+.vscode/


### PR DESCRIPTION
After build both rehid and rehidhelper I was left with these extra files and folders:
```
build/
rehid.elf
rehidhelper/build/
rehidhelper/rehidhelper.3dsx
rehidhelper/rehidhelper.elf
rehidhelper/rehidhelper.smdh
rehidhelper/sdmc/
```
In addition to a .vscode folder used by Microsoft Visual Studio Code for stuff.